### PR TITLE
Made extension methods internal to avoid conflicts with other libraries

### DIFF
--- a/GradientLoadingBar/Classes/Extensions/UIColor/UIColor+CustomColors.swift
+++ b/GradientLoadingBar/Classes/Extensions/UIColor/UIColor+CustomColors.swift
@@ -10,7 +10,7 @@ import UIKit
 
 extension UIColor {
     /// Struct that contains all our custom defined colors.
-    struct CustomColors {
+    internal struct CustomColors {
         static let grey = #colorLiteral(red: 0.8980392157, green: 0.9137254902, blue: 0.9215686275, alpha: 1)
         static let green = #colorLiteral(red: 0.2980392157, green: 0.8509803922, blue: 0.3921568627, alpha: 1)
         static let violet = #colorLiteral(red: 0.3450980392, green: 0.337254902, blue: 0.8392156863, alpha: 1)

--- a/GradientLoadingBar/Classes/Extensions/UIColor/UIColor+CustomColors.swift
+++ b/GradientLoadingBar/Classes/Extensions/UIColor/UIColor+CustomColors.swift
@@ -10,7 +10,7 @@ import UIKit
 
 extension UIColor {
     /// Struct that contains all our custom defined colors.
-    internal struct CustomColors {
+    struct CustomColors {
         static let grey = #colorLiteral(red: 0.8980392157, green: 0.9137254902, blue: 0.9215686275, alpha: 1)
         static let green = #colorLiteral(red: 0.2980392157, green: 0.8509803922, blue: 0.3921568627, alpha: 1)
         static let violet = #colorLiteral(red: 0.3450980392, green: 0.337254902, blue: 0.8392156863, alpha: 1)

--- a/GradientLoadingBar/Classes/Extensions/UIView/UIView+AnimateIsHidden.swift
+++ b/GradientLoadingBar/Classes/Extensions/UIView/UIView+AnimateIsHidden.swift
@@ -15,7 +15,7 @@ extension UIView {
     // MARK: - Config
 
     /// The default duration for fading-animations, measured in seconds.
-    internal static let defaultFadingAnimationDuration: TimeInterval = 1.0
+    static let defaultFadingAnimationDuration: TimeInterval = 1.0
 
     // MARK: - Public methods
 
@@ -28,7 +28,7 @@ extension UIView {
     ///                 argument that indicates whether or not the animations actually finished before the completion handler was called.
     ///
     /// - SeeAlso: https://developer.apple.com/documentation/uikit/uiview/1622515-animatewithduration
-    internal func animate(isHidden: Bool, duration: TimeInterval = UIView.defaultFadingAnimationDuration, completion: ((Bool) -> Void)? = nil) {
+    func animate(isHidden: Bool, duration: TimeInterval = UIView.defaultFadingAnimationDuration, completion: ((Bool) -> Void)? = nil) {
         if isHidden {
             fadeOut(duration: duration,
                     completion: completion)
@@ -46,7 +46,7 @@ extension UIView {
     ///                 argument that indicates whether or not the animations actually finished before the completion handler was called.
     ///
     /// - SeeAlso: https://developer.apple.com/documentation/uikit/uiview/1622515-animatewithduration
-    internal func fadeOut(duration: TimeInterval = UIView.defaultFadingAnimationDuration, completion: ((Bool) -> Void)? = nil) {
+    func fadeOut(duration: TimeInterval = UIView.defaultFadingAnimationDuration, completion: ((Bool) -> Void)? = nil) {
         UIView.animate(withDuration: duration,
                        animations: {
                            self.alpha = 0.0
@@ -69,7 +69,7 @@ extension UIView {
     ///                 argument that indicates whether or not the animations actually finished before the completion handler was called.
     ///
     /// - SeeAlso: https://developer.apple.com/documentation/uikit/uiview/1622515-animatewithduration
-    internal func fadeIn(duration: TimeInterval = UIView.defaultFadingAnimationDuration, completion: ((Bool) -> Void)? = nil) {
+    func fadeIn(duration: TimeInterval = UIView.defaultFadingAnimationDuration, completion: ((Bool) -> Void)? = nil) {
         if isHidden {
             // Make sure our animation is visible.
             isHidden = false

--- a/GradientLoadingBar/Classes/Extensions/UIView/UIView+AnimateIsHidden.swift
+++ b/GradientLoadingBar/Classes/Extensions/UIView/UIView+AnimateIsHidden.swift
@@ -15,7 +15,7 @@ extension UIView {
     // MARK: - Config
 
     /// The default duration for fading-animations, measured in seconds.
-    public static let defaultFadingAnimationDuration: TimeInterval = 1.0
+    internal static let defaultFadingAnimationDuration: TimeInterval = 1.0
 
     // MARK: - Public methods
 
@@ -28,7 +28,7 @@ extension UIView {
     ///                 argument that indicates whether or not the animations actually finished before the completion handler was called.
     ///
     /// - SeeAlso: https://developer.apple.com/documentation/uikit/uiview/1622515-animatewithduration
-    public func animate(isHidden: Bool, duration: TimeInterval = UIView.defaultFadingAnimationDuration, completion: ((Bool) -> Void)? = nil) {
+    internal func animate(isHidden: Bool, duration: TimeInterval = UIView.defaultFadingAnimationDuration, completion: ((Bool) -> Void)? = nil) {
         if isHidden {
             fadeOut(duration: duration,
                     completion: completion)
@@ -46,7 +46,7 @@ extension UIView {
     ///                 argument that indicates whether or not the animations actually finished before the completion handler was called.
     ///
     /// - SeeAlso: https://developer.apple.com/documentation/uikit/uiview/1622515-animatewithduration
-    public func fadeOut(duration: TimeInterval = UIView.defaultFadingAnimationDuration, completion: ((Bool) -> Void)? = nil) {
+    internal func fadeOut(duration: TimeInterval = UIView.defaultFadingAnimationDuration, completion: ((Bool) -> Void)? = nil) {
         UIView.animate(withDuration: duration,
                        animations: {
                            self.alpha = 0.0
@@ -69,7 +69,7 @@ extension UIView {
     ///                 argument that indicates whether or not the animations actually finished before the completion handler was called.
     ///
     /// - SeeAlso: https://developer.apple.com/documentation/uikit/uiview/1622515-animatewithduration
-    public func fadeIn(duration: TimeInterval = UIView.defaultFadingAnimationDuration, completion: ((Bool) -> Void)? = nil) {
+    internal func fadeIn(duration: TimeInterval = UIView.defaultFadingAnimationDuration, completion: ((Bool) -> Void)? = nil) {
         if isHidden {
             // Make sure our animation is visible.
             isHidden = false


### PR DESCRIPTION
Public UIView extension methods `fadeIn(duration:, completion:)` and `fadeOut(duration:, completion:)` were conflicting with other libraries (e.g. [SwifterSwift](https://swifterswift.com/)) own `fadeIn(duration:, completion:)` and `fadeOut(duration:, completion:)` causing the compiler to raise `ambiguous use of ...` type errors. Since the goal for this library is to provide a great loading bar (which it does masterfully) and not new UIView functionality, its extension methods should be `internal`.