### PR TITLE
Support of Swift Package Manager

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/GradientLoadingBar/Classes/Misc/Constants.swift
+++ b/GradientLoadingBar/Classes/Misc/Constants.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Felix Mau. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 extension UIColor {
     /// Default colors for components.

--- a/GradientLoadingBar/Classes/ViewModel/GradientActivityIndicatorViewModel.swift
+++ b/GradientLoadingBar/Classes/ViewModel/GradientActivityIndicatorViewModel.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Felix Mau. All rights reserved.
 //
 
-import Foundation
+import UIKit
 import LightweightObservable
 
 // MARK: - Types

--- a/GradientLoadingBar/Classes/ViewModel/GradientLoadingBarViewModel.swift
+++ b/GradientLoadingBar/Classes/ViewModel/GradientLoadingBarViewModel.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Felix Mau. All rights reserved.
 //
 
-import Foundation
+import UIKit
 import LightweightObservable
 
 /// This view model checks for the availability of the key-window,

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "LightweightObservable",
+        "repositoryURL": "https://github.com/fxm90/LightweightObservable",
+        "state": {
+          "branch": null,
+          "revision": "b689038f3dcb2564d2bc6c4f710765776d5b9356",
+          "version": "2.0.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "GradientLoadingBar",
+    platforms: [.iOS(.v9)],
+    products: [
+        .library(
+            name: "GradientLoadingBar",
+            targets: ["GradientLoadingBar"]
+        )
+    ],
+    dependencies: [
+        .package(
+            url: "https://github.com/fxm90/LightweightObservable",
+            .upToNextMajor(from: "2.0.0")
+        )
+    ],
+    targets: [
+        .target(
+            name: "GradientLoadingBar",
+            dependencies: ["LightweightObservable"],
+            path: "GradientLoadingBar/Classes"
+        )
+    ]
+)


### PR DESCRIPTION
Adds `Package.swift` file which enables usage with SPM.
**Note**, that the most correct usage with SPM will be possible only when there is new release that includes `Package.swift`. Until then, dependency can be added by branch or commit hash which is not allowed in published packages.